### PR TITLE
Ensure Supabase client usage is consistent in the UI

### DIFF
--- a/src/lib/components/setting/AI.svelte
+++ b/src/lib/components/setting/AI.svelte
@@ -6,9 +6,8 @@
 
 	const toastStore = getToastStore();
 
-	export let data;
-	let { supabase } = data;
-	$: ({ supabase } = data);
+        export let data;
+        void data;
 
 	const ai = new AI();
 	let AIObj = ai.emptyObject();

--- a/src/lib/components/setting/APIs.svelte
+++ b/src/lib/components/setting/APIs.svelte
@@ -6,9 +6,8 @@
 
 	const toastStore = getToastStore();
 
-	export let data;
-	let { supabase } = data;
-	$: ({ supabase } = data);
+        export let data;
+        void data;
 
 	const apis = new ThirdPartyAPIs();
 	let API = apis.emptyObject();

--- a/src/lib/components/setting/Language.svelte
+++ b/src/lib/components/setting/Language.svelte
@@ -11,13 +11,23 @@
 	const toastStore = getToastStore();
 
 	export let data;
-	const supabase = browser ? getSupabaseBrowserClient() : null;
+        const supabase = browser ? getSupabaseBrowserClient() : null;
+        const getSupabaseClient = () => {
+                if (!supabase) {
+                        throw new Error('Supabase browser client requested outside the browser context.');
+                }
+
+                return supabase;
+        };
 	$: languages = [];
 
 	// 获取所有语言
 	const getLanguages = async () => {
-		const { data, error: fetchError } = await
-			supabase.from('language').select('lang, locale, is_default').order('is_default', { ascending: false });
+                const client = getSupabaseClient();
+                const { data, error: fetchError } = await client
+                        .from('language')
+                        .select('lang, locale, is_default')
+                        .order('is_default', { ascending: false });
 		if (fetchError) {
 			console.error(fetchError);
 			toastStore.trigger({
@@ -34,7 +44,8 @@
 
 	// 更换默认语言
 	const setDefaultLanguage = async (lang: string) => {
-		await supabase.from('language').update({ is_default: true }).eq('lang', lang);
+                const client = getSupabaseClient();
+                await client.from('language').update({ is_default: true }).eq('lang', lang);
 		await getLanguages();
 		toastStore.trigger({
 			message: $t('language-set-default'),
@@ -45,8 +56,8 @@
 
 	// 添加语言
 	const addLanguage = async (lang, locale) => {
-		const { error: dataError } = await
-			supabase.from('language').insert({ lang, locale }).select();
+                const client = getSupabaseClient();
+                const { error: dataError } = await client.from('language').insert({ lang, locale }).select();
 		if (dataError) {
 			console.error(dataError);
 			toastStore.trigger({
@@ -65,9 +76,11 @@
 
 	// 删除语言
 	const deleteLanguage = async (lang: string) => {
-		const { error: deleteError } = await
-			supabase.from('language').delete().eq('lang',
-				lang);
+                const client = getSupabaseClient();
+                const { error: deleteError } = await client
+                        .from('language')
+                        .delete()
+                        .eq('lang', lang);
 		if (deleteError) {
 			console.error(deleteError);
 			toastStore.trigger({

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,19 +3,14 @@
 	import { invalidate } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import '../app.css';
-	import { initializeStores, Toast } from '$lib/toast';
-	import { createBrowserClient } from '@supabase/ssr';
-	import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
+        import { initializeStores, Toast } from '$lib/toast';
+        import { getSupabaseBrowserClient } from '$lib/supabaseClient';
 
 	initializeStores();
 
 	export let data;
-	let { session, user, message_count, comment_count } = data;
-	let supabase;
-
-	if (browser) {
-		supabase = createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY);
-	}
+        let { session, user, message_count, comment_count } = data;
+        const supabase = browser ? getSupabaseBrowserClient() : null;
 
 	onMount(() => {
 		if (!supabase) return;


### PR DESCRIPTION
## Summary
- reuse the shared Supabase browser client helper in the root layout
- guard the settings language component against missing Supabase clients during SSR
- remove unused Supabase destructuring in the AI and API settings panels

## Testing
- pnpm lint *(fails: repository has existing Prettier formatting warnings across many files)*

------
https://chatgpt.com/codex/tasks/task_e_690c0798f2248322abbe3f4bf91d5ab8