### PR TITLE
Redirect logged in users and remove chart

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,0 +1,10 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (locals.session) {
+		throw redirect(303, '/admin');
+	}
+
+	return {};
+};

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import PageTitle from '$components/PageTitle.svelte';
-	import StatsChart from '$components/admin/StatsChart.svelte';
 	import type { StatsMetricKey, StatsRow } from '$lib/types/stats';
 
 	type PageData = {
@@ -76,24 +75,6 @@
 				</p>
 			</section>
 		{/if}
-
-		<section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-			<header class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<h3 class="text-lg font-semibold text-slate-900">内容趋势</h3>
-					<p class="text-sm text-slate-500">最近 30 天内容与互动数据走势</p>
-				</div>
-				{#if latestSnapshot}
-					<p class="text-sm text-slate-400">
-						最后更新：{new Date(latestSnapshot.date).toLocaleDateString('zh-CN')}
-					</p>
-				{/if}
-			</header>
-
-			<div class="mt-6">
-				<StatsChart stats={data.stats} />
-			</div>
-		</section>
 
 		{#if data.stats.length === 0}
 			<section class="rounded-lg border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-slate-500">


### PR DESCRIPTION
Redirect logged-in users to `/admin` and remove the chart from the `/admin` page to streamline navigation and simplify the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-d30ccfe7-a02c-4fdb-b9c6-43a6bc37e338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d30ccfe7-a02c-4fdb-b9c6-43a6bc37e338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

